### PR TITLE
Added Links section on Client README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-User stories:
+# Sserpdrow Client
 
-ERD:
+## Links
 
-Wireframes:
+Client Deployed: https://wdi-honey-badgers.github.io/sserpdrow-client/
+Client Repo: https://github.com/wdi-honey-badgers/sserpdrow-api
+API Deployed: https://honey-badgers-sserpdrow-api.herokuapp.com/
+API Repo:  https://github.com/wdi-honey-badgers/sserpdrow-api
 
-Deployed links:
+## User stories:
 
-Story about development planning/obstacles:
+## ERD:
+
+## Wireframes:
+
+## Deployed links:
+
+## Story about development planning/obstacles:


### PR DESCRIPTION
This commit adds a link section on README, including the client
deployed link, client repo link, api deployed link, and api repo link.

Additionally, we decided moving forward we will have identical README's
for both API and Client repos, each including all requirements
necessary for either.