### PR TITLE
User Auth reveal/hide & clear forms

### DIFF
--- a/assets/scripts/api.js
+++ b/assets/scripts/api.js
@@ -3,6 +3,7 @@
 const config = require('./config.js')
 const store = require('./store')
 
+// Auth
 const signUp = function (data) {
   console.log('api signUp')
   return $.ajax({
@@ -44,6 +45,7 @@ const signOut = function () {
   })
 }
 
+// Posts
 const addPosts = function (data) {
   return $.ajax({
     method: 'POST',

--- a/assets/scripts/auth-events.js
+++ b/assets/scripts/auth-events.js
@@ -1,9 +1,8 @@
 'use strict'
 
+const getFormFields = require('../../lib/get-form-fields')
 const authApi = require('./api.js')
 const authUi = require('./ui.js')
-// const events = require('./events.js')
-const getFormFields = require('../../lib/get-form-fields')
 
 const onSignUp = function (event) {
   event.preventDefault()
@@ -22,7 +21,6 @@ const onSignIn = function (event) {
   console.log('Lt. Commander Data is ', data)
   authApi.signIn(data)
     .then(authUi.signInSuccess)
-    // .then(events.onGetPosts)
     .catch(authUi.error)
 }
 
@@ -38,7 +36,7 @@ const onChangePassword = function (event) {
 
 const onSignOut = function (event) {
   event.preventDefault()
-  console.log("nooooo don't leave meeeee :'(")
+  console.log('Where do you think you are going bub -_-*')
   authApi.signOut()
     .then(authUi.signOutSuccess)
     .catch(authUi.error)

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -1,110 +1,113 @@
 'use strict'
 
 const store = require('./store')
-// const showCookiesTemplate = require('./templates/baker-posts.handlebars')
 
-let signedIn = false
+// Assistant Functions
+const clearMessageDiv = function () {
+  $('#userFacingMsg').html('')
+}
 
+// The terms "external" and "internal" are references to visitor view vs user signed-in view. Someone who is not signed in will see the "external" view state, where as user who are signed-in will see the "internal" view state.
+const revealChangePassSignOut = function () {
+  const authInternal = document.getElementById('authInternal')
+  authInternal.classList.remove('hidden')
+}
+
+const revealSignUpSignIn = function () {
+  const userAuthExternal = document.getElementById('authExternal')
+  userAuthExternal.classList.remove('hidden')
+}
+
+const hideChangePassSignOut = function () {
+  const authInternal = document.getElementById('authInternal')
+  authInternal.classList.add('hidden')
+}
+
+const hideSignUpSignIn = function () {
+  const authExternal = document.getElementById('authExternal')
+  authExternal.classList.add('hidden')
+}
+
+const clearFormFields = function () {
+  document.getElementById('sign-up-form').reset()
+  document.getElementById('sign-in-form').reset()
+  document.getElementById('change-pw-form').reset()
+}
+
+// Success & Error Functions
 const signUpSuccess = function (signUpSuccess) {
-  console.log('sing up success')
-  formResets()
-  // clearText()
-  $('#info').append('You now have an account. Please sign in.')
+  clearMessageDiv()
+  $('#userFacingMsg').append('You now have an account. Please sign in.')
+  clearFormFields()
+  console.log('sign up success')
 }
 
 const signInSuccess = function (data) {
-  console.log('log in success')
+  clearMessageDiv()
   store.user = data.user
-  formResets()
-  // clearText()
-  signedIn = true
-  // $('.pre-sign-in').hide()
-  // $('.signed-in').show()
+  $('#userFacingMsg').append('You have signed in.')
+  clearFormFields()
+  revealChangePassSignOut()
+  hideSignUpSignIn()
+  console.log('log in success')
 }
 
 const changePasswordSuccess = function (changePasswordSuccess) {
+  clearMessageDiv()
+  $('#userFacingMsg').append('Password changed, now dont forget it!')
+  clearFormFields()
   console.log('change password success')
-  formResets()
-  // clearText()
-  // $('#info').append('Password changed.')
 }
 
 const signOutSuccess = function (signOutSuccess) {
+  clearMessageDiv()
+  $('#userFacingMsg').append('Bye. Come again!')
+  clearFormFields()
+  hideChangePassSignOut()
+  revealSignUpSignIn()
+  delete store.user
   console.log('successfully left me')
-  formResets()
-  // clearText()
-  signedIn = false
-  // $('#info').append('Bye. Come again!')
-  // $('.signed-in').hide()
-  // $('.pre-sign-in').show()
 }
 
-const addPostsSuccess = function (data) {
-  formResets()
-  // clearText()
-//   $('#info').append('Noted!')
-}
-
-const getPostsSuccess = (data) => {
-//   postTable(data)
-  formResets()
-  // clearText()
-  store.post = data.posts
-}
-
-// const postTable = function (data) {
-//   $('td').remove()
-//   const showPostsHtml = showPostsTemplate({ posts: data.posts })
-//   $('thead').append(showPostsHtml)
+// const addPostsSuccess = function (data) {
+//   clearMessageDiv()
+//   $('#userFacingMsg').append('Noted!')
 // }
 //
-const editPostsSuccess = function (data) {
-  formResets()
-  // clearText()
+// const getPostsSuccess = (data) => {
+//   clearMessageDiv()
+//   store.post = data.posts
+// }
+//
+// const editPostsSuccess = function (data) {
+//   clearMessageDiv()
 //   $('#edit-posts').hide()
 //   $('#delete-posts').hide()
-//   $('#info').append('Noted!')
-}
-
-const deletePostsSuccess = function (data) {
+//   $('#userFacingMsg').append('Noted!')
+// }
+//
+// const deletePostsSuccess = function (data) {
 //   $('#edit-posts').hide()
 //   $('#delete-posts').hide()
-  formResets()
-  // clearText()
-//   $('#info').append('Noted!')
-}
+//   clearMessageDiv()
+//   $('#userFacingMsg').append('Noted!')
+// }
 
 const error = function () {
+  clearMessageDiv()
+  $('#userFacingMsg').append('Error! Try again.')
+  clearFormFields()
   console.log('errored!')
-  // clearText()
-  formResets()
-  // $('#info').append('Error! Try again.')
 }
-
-const formResets = function () {
-  if (signedIn === true) {
-    $('#edit-posts-form').reset()
-    $('#change-pw-form').reset()
-    $('#add-post-form').reset()
-    $('#delete-posts-form').reset()
-  } else {
-    $('#sign-in-form').reset()
-    $('#sign-up-form').reset()
-  }
-}
-
-// const clearText = function () {
-//   document.getElementById('info').textContent = ''
-// }
 
 module.exports = {
   signUpSuccess,
   signInSuccess,
   changePasswordSuccess,
   signOutSuccess,
-  addPostsSuccess,
-  getPostsSuccess,
-  editPostsSuccess,
-  deletePostsSuccess,
+  // addPostsSuccess,
+  // getPostsSuccess,
+  // editPostsSuccess,
+  // deletePostsSuccess,
   error
 }

--- a/index.html
+++ b/index.html
@@ -12,10 +12,8 @@
       <script src="public/application.js" type="text/javascript" charset="utf-8" defer></script>
     </head>
     <body>
-
       <h1>Sserp, Drow?</h1>
       <h2>Not much. Sserp with you?</h2>
-
       <nav class="sidebar">
         <ul class="user">
           <li>User</li>
@@ -24,59 +22,58 @@
           <li>Here</li>
         </ul>
       </nav>
-
       <nav class="sidebar">
-      <ul class="user visitor">
-        <li>Organization 1 is a link</li>
-        <li>Organization 2 is a link</li>
-        <li>Organization 3 is a link</li>
-        <li>Organization 4 is a link</li>
-      </ul>
-    </nav>
-
-    <div>
-      <ul>
-        <li class="visitor" id='sign-in-form'>
-          <form>
-            <input name="credentials[email]" placeholder="email" type="text">
-            <input name="credentials[password]" placeholder="password" type="password">
-            <button type="submit">Log In</button>
-          </form>
-        </li>
-        <li class="visitor" id='sign-up-form'>
-          <form>
-            <input name="credentials[email]" placeholder="email" type="email">
-            <!-- <input name="credentials[screen_name]" placeholder="name" type="text"> -->
-            <input name="credentials[password]" placeholder="password" type="password">
-            <input name="credentials[password_confirmation]" placeholder="password again" type="password">
-            <button type="submit">Make an Account</button>
-          </form>
-        </li>
-        <li class="users" id='change-pw-form'>
-          <form>
-            <input name="passwords[old]" placeholder="old password" type="password">
-            <input name="passwords[new]" placeholder="new password" type="password">
-            <button type="submit">Change Password</button>
-          </form>
-        </li>
-        <li class="users" id='sign-out'>
-          <button>Sign Out</button>
-        </li>
-      </ul>
-    </div>
-
-    <div class="pages">
-      Webpages links get populated here.
-      <!--  id shpould be populated by handlebars to be unique  -->
-      <button class="user" id="update">Update</button>
-      <button class="user" id="delete">Delete</button>
-    </div>
-
-    <div class="posts">
-      Blog posts get populated here.
-      <!--  id shpould be populated by handlebars to be unique  -->
-      <button class="user" id="update">Update</button>
-      <button class="user" id="delete">Delete</button>
-    </div>
+        <ul class="user visitor">
+          <li>Organization 1 is a link</li>
+          <li>Organization 2 is a link</li>
+          <li>Organization 3 is a link</li>
+          <li>Organization 4 is a link</li>
+        </ul>
+      </nav>
+      <div id="userFacingMsg"></div>
+      <div class="auth">
+        <ul class="auth-external" id="authExternal">
+          <li>
+            <form id='sign-in-form'>
+              <input name="credentials[email]" placeholder="email" type="text">
+              <input name="credentials[password]" placeholder="password" type="password">
+              <button type="submit">Log In</button>
+            </form>
+          </li>
+          <li>
+            <form id='sign-up-form'>
+              <input name="credentials[email]" placeholder="email" type="email">
+              <!-- <input name="credentials[screen_name]" placeholder="name" type="text"> -->
+              <input name="credentials[password]" placeholder="password" type="password">
+              <input name="credentials[password_confirmation]" placeholder="password again" type="password">
+              <button type="submit">Make an Account</button>
+            </form>
+          </li>
+        </ul>
+        <ul class="auth-internal hidden" id="authInternal">
+          <li>
+            <form id='change-pw-form'>
+              <input name="passwords[old]" placeholder="old password" type="password">
+              <input name="passwords[new]" placeholder="new password" type="password">
+              <button type="submit">Change Password</button>
+            </form>
+          </li>
+          <li id='sign-out'>
+            <button>Sign Out</button>
+          </li>
+        </ul>
+      </div>
+      <div class="pages">
+        Webpages links get populated here.
+        <!--  id should be populated by handlebars to be unique  -->
+        <button class="user" id="update">Update</button>
+        <button class="user" id="delete">Delete</button>
+      </div>
+      <div class="posts">
+        Blog posts get populated here.
+        <!--  id should be populated by handlebars to be unique  -->
+        <button class="user" id="update">Update</button>
+        <button class="user" id="delete">Delete</button>
+      </div>
     </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4425,8 +4425,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -4511,7 +4510,6 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -4699,7 +4697,6 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -4773,8 +4770,7 @@
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -4991,7 +4987,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5307,7 +5302,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }


### PR DESCRIPTION
This commit features new user auth functionality to reveal or hide
various forms depending on the sign-in/sign-out status of a user. On
successful sign in, the sign-up/sign-in forms hide and the
change-password/sign-out forms are revealed, and the reverse happens
when the user signs out.

This commit also features the ability to clear form fields, as per
requirements. Regardless of success or error, each time a form is
submitted, all auth form fields are cleared. This feature also
required an adjustment to the index.html because the id necessary for
this to work was not on the <form> elements but were on the parent
<li> element instead.